### PR TITLE
Drop "Active Member" label from Past Contributors

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -39,7 +39,6 @@ layout: page
                 <div class="col-md-3 col-xs-6 col-sm-6">
                     <img src={{member.imageSrc}} class=" center-block img-responsive img-circle" alt="{{member.name}}" height="100" width="100">
                     <h5 class="margin-bottom-0">{{member.name}}</h5>
-                    <p class="text-uppercase">Active Member</p>
                 </div>
                 <div class="visible-xs">
                         {% assign offset = forloop.index | modulo: 2 %}


### PR DESCRIPTION
Follow-up to #91. The contributors section was renamed to "Past Contributors", so the per-person "Active Member" caption no longer makes sense — removed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)