### PR TITLE
Move community photo to hero, below the GDG Baroda title

### DIFF
--- a/app.scss
+++ b/app.scss
@@ -773,9 +773,10 @@ a.ed:hover, a.ed:focus-visible { background-size: 100% 2px; }
 
 /* ===================== press photo band ===================== */
 .press-band {
-  margin: clamp(1.5rem, 4vw, 3rem) 0 0;
+  margin: 0;
   border-block: var(--rule) solid var(--ink);
 }
+.hero-rest { padding-block: clamp(1.75rem, 4vw, 2.75rem); }
 .press-band img {
   width: 100%;
   height: clamp(190px, 36vw, 420px);

--- a/index.html
+++ b/index.html
@@ -11,7 +11,15 @@ layout: base
   <h1 class="nameplate" id="site-title">GDG&nbsp;Baroda</h1>
 
   <div class="rule4" aria-hidden="true"><i></i><i></i><i></i><i></i></div>
+</section>
 
+<!-- ===================== HERO PHOTO ===================== -->
+<figure class="press-band">
+  <img src="{{ '/assets/community/devfest-2025-group.jpg' | relative_url }}" alt="The GDG Baroda community gathered at DevFest 2025" width="2000" height="666" loading="eager" fetchpriority="high">
+  <figcaption class="wrap"><span class="bk" aria-hidden="true">&lt;/&gt;</span> The GDG Baroda community &mdash; DevFest 2025</figcaption>
+</figure>
+
+<section class="hero-rest wrap" aria-label="Latest dispatch">
   <div class="hero-grid">
     <div class="lead">
       <span class="kicker">from the masthead</span>
@@ -41,12 +49,6 @@ layout: base
     </aside>
   </div>
 </section>
-
-<!-- ===================== PRESS PHOTO ===================== -->
-<figure class="press-band">
-  <img src="{{ '/assets/community/devfest-2025-group.jpg' | relative_url }}" alt="The GDG Baroda community gathered at DevFest 2025" width="2000" height="666" loading="lazy">
-  <figcaption class="wrap"><span class="bk" aria-hidden="true">&lt;/&gt;</span> The GDG Baroda community &mdash; DevFest 2025</figcaption>
-</figure>
 
 <!-- ===================== THE BRIEF ===================== -->
 <section class="brief wrap" aria-label="Our mission">


### PR DESCRIPTION
Promotes the DevFest 2025 group photo from a mid-page band to a full-bleed hero band directly under the GDG Baroda nameplate + four-colour rule (above the featured story). Eager-loaded as the LCP image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)