### PR TITLE
Add DevFest timeline page (/devfest/)

### DIFF
--- a/_scss/post.scss
+++ b/_scss/post.scss
@@ -184,3 +184,42 @@
   border-color: var(--g-blue);
   box-shadow: 4px 4px 0 var(--g-blue);
 }
+
+/* ===================== DevFest timeline ===================== */
+.timeline { list-style: none; margin: 1.8rem 0 0; padding: 0; }
+.tl { display: grid; grid-template-columns: 4.5rem 1fr; gap: 0 1.4rem; }
+.tl-year {
+  font-family: var(--display); font-weight: 600; font-size: 1.7rem;
+  line-height: 1; margin: 0; padding-top: .05rem; color: var(--ink);
+}
+.tl-body {
+  border-left: var(--rule) solid var(--hairline);
+  padding: 0 0 2rem 1.5rem; position: relative;
+}
+.tl:last-child .tl-body { padding-bottom: .3rem; }
+.tl-body::before {
+  content: ''; position: absolute; left: -7px; top: .35rem;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--g-blue); box-shadow: 0 0 0 3px var(--newsprint);
+}
+.tl:nth-child(4n+2) .tl-body::before { background: var(--g-red); }
+.tl:nth-child(4n+3) .tl-body::before { background: var(--g-yellow); }
+.tl:nth-child(4n)   .tl-body::before { background: var(--g-green); }
+.tl-date {
+  font-family: var(--mono); font-size: .76rem; letter-spacing: .06em;
+  text-transform: uppercase; margin: 0 0 .2rem; color: var(--ink);
+}
+.tl-where { margin: 0; color: var(--graphite); }
+.tl-note { margin: .3rem 0 0; color: var(--graphite); font-size: .95rem; }
+.tl-body .ed { display: inline-block; margin-top: .55rem; }
+.tl--soft .tl-year, .tl--soft .tl-date { color: var(--graphite); }
+.tl-foot {
+  margin: 1.8rem 0 0; padding-top: 1rem; border-top: var(--rule) solid var(--hairline);
+  font-size: .9rem; color: var(--graphite);
+}
+@media (max-width: 480px) {
+  .tl { grid-template-columns: 1fr; }
+  .tl-year { padding: 0 0 .25rem 1.5rem; }
+  .tl-body { border-left: none; padding-left: 1.5rem; }
+  .tl-body::before { display: none; }
+}

--- a/devfest.html
+++ b/devfest.html
@@ -1,0 +1,87 @@
+---
+layout: base
+title: DevFest Through the Years
+permalink: /devfest/
+description: A timeline of GDG Baroda's flagship DevFest, edition by edition since 2017.
+---
+<section class="posts-head wrap">
+  <a class="back-link" href="/">&lt;/ back to home &gt;</a>
+  <p class="dateline">Vadodara · Gujarat — Our flagship, edition by edition</p>
+  <h1 class="nameplate-sm section-head"><span class="bk">&lt;</span> DevFest Through the Years <span class="bk">/&gt;</span></h1>
+  <div class="rule4" aria-hidden="true"><i></i><i></i><i></i><i></i></div>
+</section>
+
+<section class="section wrap wrap--narrow" style="padding-top:1.5rem">
+  <p class="eyebrow"><span class="tok">//</span> our flagship, since <span class="num">2017</span></p>
+
+  <ol class="timeline">
+    <li class="tl">
+      <h2 class="tl-year">2017</h2>
+      <div class="tl-body">
+        <p class="tl-date">1 October 2017 · Sunday</p>
+        <p class="tl-where">Four Points by Sheraton, Vadodara</p>
+        <p class="tl-note">Our very first DevFest.</p>
+        <a class="ed" href="https://gdg.community.dev/events/details/google-google-developers-group-baroda-gdg-baroda-presents-gdg-baroda-devfest-2017/" target="_blank" rel="noopener">On GDG Community →</a>
+      </div>
+    </li>
+    <li class="tl">
+      <h2 class="tl-year">2018</h2>
+      <div class="tl-body">
+        <p class="tl-date">30 September 2018 · Sunday</p>
+        <p class="tl-note">Theme: cross-platform apps with Flutter.</p>
+        <a class="ed" href="https://gdg.community.dev/events/details/google-google-developers-group-baroda-gdg-baroda-presents-gdg-devfest-baroda-2018/" target="_blank" rel="noopener">On GDG Community →</a>
+      </div>
+    </li>
+    <li class="tl">
+      <h2 class="tl-year">2019</h2>
+      <div class="tl-body">
+        <p class="tl-date">21–22 September 2019 · Sat–Sun · two days</p>
+        <p class="tl-where">Sayaji Hotel, Vadodara</p>
+        <p class="tl-note">Co-hosted with Kotlin/Everywhere Baroda.</p>
+        <a class="ed" href="https://gdg.community.dev/events/details/google-google-developers-group-baroda-gdg-baroda-presents-gdg-devfest-baroda-2019-kotlineverywhere-baroda-2019/" target="_blank" rel="noopener">On GDG Community →</a>
+      </div>
+    </li>
+    <li class="tl tl--soft">
+      <h2 class="tl-year">2020</h2>
+      <div class="tl-body">
+        <p class="tl-date">16–18 October 2020 · online</p>
+        <p class="tl-note">No in-person Baroda edition — during COVID the chapter joined the pan-India virtual <strong>DevFest India</strong>.</p>
+        <a class="ed" href="https://gdg.community.dev/events/details/google-gdg-baroda-presents-devfest-india/" target="_blank" rel="noopener">On GDG Community →</a>
+      </div>
+    </li>
+    <li class="tl tl--soft">
+      <h2 class="tl-year">2021</h2>
+      <div class="tl-body">
+        <p class="tl-date">22–24 October 2021 · online</p>
+        <p class="tl-note">Again virtual — the chapter joined <strong>DevFest India 2021</strong>.</p>
+        <a class="ed" href="https://gdg.community.dev/events/details/google-gdg-baroda-presents-devfest-india-2021/" target="_blank" rel="noopener">On GDG Community →</a>
+      </div>
+    </li>
+    <li class="tl">
+      <h2 class="tl-year">2022</h2>
+      <div class="tl-body">
+        <p class="tl-date">24 December 2022 · Saturday</p>
+        <p class="tl-where">Fairfield by Marriott, Vadodara</p>
+        <p class="tl-note">Back in person after the pandemic.</p>
+        <a class="ed" href="https://gdg.community.dev/events/details/google-gdg-baroda-presents-gdg-devfest-baroda-2022/" target="_blank" rel="noopener">On GDG Community →</a>
+      </div>
+    </li>
+    <li class="tl">
+      <h2 class="tl-year">2024</h2>
+      <div class="tl-body">
+        <p class="tl-date">1 December 2024 · Sunday</p>
+        <p class="tl-where">Hyatt Place, Vadodara</p>
+        <a class="ed" href="https://gdg.community.dev/events/details/google-gdg-baroda-presents-gdg-baroda-devfest-2024/" target="_blank" rel="noopener">On GDG Community →</a>
+      </div>
+    </li>
+    <li class="tl">
+      <h2 class="tl-year">2025</h2>
+      <div class="tl-body">
+        <p class="tl-date">4–5 October 2025 · Sat–Sun · two days</p>
+        <p class="tl-where">Sayaji Hotel, Vadodara</p>
+        <p class="tl-note">Workshops on day one; talks &amp; keynotes on day two.</p>
+        <a class="ed" href="https://devfest.gdgbaroda.com" target="_blank" rel="noopener">Visit devfest.gdgbaroda.com →</a>
+      </div>
+    </li>
+  </ol>
+</section>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@ layout: base
         <p class="e-kicker">Flagship</p>
         <h3>DevFest</h3>
         <p>Our biggest annual gathering — talks, codelabs, and the wider developer community under one roof.</p>
-        <p class="e-foot">Annual · Vadodara</p>
+        <p class="e-foot">Annual · Vadodara · <a class="ed" href="/devfest/">Through the years →</a></p>
       </article>
       <article class="edition">
         <p class="e-kicker">Watch Party</p>


### PR DESCRIPTION
New "DevFest Through the Years" page (/devfest/) listing every edition 2017-2025 as an editorial vertical timeline with GDG-colour markers, linked from the homepage "series" card. 2020/2021 are shown as the virtual DevFest India years; 2023 is omitted (no edition was held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)